### PR TITLE
Nexus Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also specify separate download roots for npm and node as they are stored
 </plugin>
 ```
 
-You can use Nexus repository Manager to proxy npm registries. See https://books.sonatype.com/nexus-book/reference/npm.html
+You can use Nexus repository Manager to proxy npm registries. See https://help.sonatype.com/display/NXRM3/Node+Packaged+Modules+and+npm+Registries
 
 **Notice:** _Remember to gitignore the `node` folder, unless you actually want to commit it._
 


### PR DESCRIPTION
**Summary**

Just updating the link to the Nexus documentation as the old link now redirects to a generic page for Nexus Repository Manager 2 rather than instructions for setting up NPM with Nexus.
